### PR TITLE
Support user index name override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ format: isort
 
 test:
 	docker stop $(OPENSEARCH_CONTAINER_NAME) || true
-	docker run -d --rm --name $(OPENSEARCH_CONTAINER_NAME) -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" opensearchproject/opensearch:2.0.1
+	docker run -d --rm --name $(OPENSEARCH_CONTAINER_NAME) -p 9200:9200 -p 9600:9600 -e "discovery.type=single-node" opensearchproject/opensearch:2.3.0
 	pytest --cov=fastapi_users_db_opensearch/
 	docker stop $(OPENSEARCH_CONTAINER_NAME)
 

--- a/fastapi_users_db_opensearch/__init__.py
+++ b/fastapi_users_db_opensearch/__init__.py
@@ -8,7 +8,7 @@ from opensearchpy import AsyncOpenSearch
 from pydantic import UUID4
 
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 
 class OpenSearchUserDatabase(BaseUserDatabase[UD]):
@@ -22,10 +22,11 @@ class OpenSearchUserDatabase(BaseUserDatabase[UD]):
         self,
         user_db_model: Type[UD],
         client: AsyncOpenSearch,
+        user_index: str = "user",
     ):
         super().__init__(user_db_model)
         self.client = client
-        self.user_index = "user"
+        self.user_index = user_index
 
     async def get(self, id: UUID4) -> Optional[UD]:
         """Get a single user by id."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 fastapi-users >= 9.1.0,<10.0.0
-opensearch-py >= 1.0.0,<=2.0.1
-opensearch-py[async] >= 1.0.0,<=2.0.1
+opensearch-py >= 1.0.0,<3.0.0
+opensearch-py[async] >= 1.0.0,<3.0.0


### PR DESCRIPTION
1. Support overriding user index name
2. Expand opensearch-py, opensearch-py[async] version range
3. Update opensearch docker version to 2.3